### PR TITLE
Allow model to be instantiated as a SubBlocks module

### DIFF
--- a/lib/cross_origen.rb
+++ b/lib/cross_origen.rb
@@ -82,10 +82,6 @@ module CrossOrigen
   def cr_ip_xact
     @cr_ip_xact ||= IpXact.new(self)
   end
-  
-  def cr_sgxml
-		@cr_sgxml ||= SgXML.new(self)
-  end
 
   private
 
@@ -95,8 +91,6 @@ module CrossOrigen
     case snippet
     when /spiritconsortium/
       cr_ip_xact
-		when /SGXML/
-			cr_sgxml
     else
       fail "Unknown file format for file: #{file}"
     end

--- a/lib/cross_origen.rb
+++ b/lib/cross_origen.rb
@@ -65,7 +65,8 @@ module CrossOrigen
   def cr_to_origen(options = {})
     options = {
       obj:  $dut,
-      path: Origen.app.config.output_directory
+      path: nil,
+			instantiate_level: :top
     }.update(options)
     # This method assumes and checks for $self to contain Origen::Model
     error "ERROR: #{options[:obj].class} does not contain Origen::Model as required" unless options[:obj].class < Origen::Model
@@ -81,6 +82,10 @@ module CrossOrigen
   def cr_ip_xact
     @cr_ip_xact ||= IpXact.new(self)
   end
+  
+  def cr_sgxml
+		@cr_sgxml ||= SgXML.new(self)
+  end
 
   private
 
@@ -90,6 +95,8 @@ module CrossOrigen
     case snippet
     when /spiritconsortium/
       cr_ip_xact
+		when /SGXML/
+			cr_sgxml
     else
       fail "Unknown file format for file: #{file}"
     end

--- a/lib/cross_origen.rb
+++ b/lib/cross_origen.rb
@@ -64,9 +64,9 @@ module CrossOrigen
   # The Ruby files are created at options[:path] (app output directory by default)
   def cr_to_origen(options = {})
     options = {
-      obj:  $dut,
-      path: nil,
-			instantiate_level: :top
+      obj:               $dut,
+      path:              Origen.app.config.output_directory,
+      instantiate_level: :top
     }.update(options)
     # This method assumes and checks for $self to contain Origen::Model
     error "ERROR: #{options[:obj].class} does not contain Origen::Model as required" unless options[:obj].class < Origen::Model

--- a/lib/cross_origen/origen_format.rb
+++ b/lib/cross_origen/origen_format.rb
@@ -25,14 +25,14 @@ module CrossOrigen
 
     def initialize(options = {})
       options = {
-        obj:  $dut,
-        path: "#{Origen.root!}/output",
-				instantiate_level: :top
+        obj:               $dut,
+        path:              "#{Origen.root!}/output",
+        instantiate_level: :top
       }.update(options)
       @obj = options[:obj]
       @output_dir = options[:path]
-			@inst_level = options[:instantiate_level]
-			fail "@instantiate_level must be either set to ':top' or ':sub_block'" unless [:top, :sub_block].include?(@inst_level)
+      @inst_level = options[:instantiate_level]
+      fail "@instantiate_level must be either set to ':top' or ':sub_block'" unless [:top, :sub_block].include?(@inst_level)
       @top_level_path = "#{output_dir}/top_level.rb"
       @incl_path = "#{output_dir}/sub_blocks.rb"
       @incl_dir = "#{output_dir}/import"
@@ -75,22 +75,22 @@ module CrossOrigen
         bom_file.puts(FILE_COMMENTS[:incl])
         bom_file.puts("require_relative 'sub_blocks'")
         @top_level_hierarchy.each do |name, obj|
-					if(@inst_level == :sub_block && @top_level_hierarchy.keys.last == name)
-						obj = "module"
-						name = "SubBlocks"
-				  end
-					bom_file.puts("#{indent}#{obj} #{name.split('::').last}")
-					indent += '  '
+          if @inst_level == :sub_block && @top_level_hierarchy.keys.last == name
+            obj = 'module'
+            name = 'SubBlocks'
+          end
+          bom_file.puts("#{indent}#{obj} #{name.split('::').last}")
+          indent += '  '
         end
         bom_file.puts("#{indent}include Origen::Model")
         bom_file.puts('')
-				if @inst_level == :sub_block
-					bom_file.puts("#{indent}def instantiate_sub_blocks(options = {})")
-				elsif @inst_level == :top
-					bom_file.puts("#{indent}def initialize(options = {})")
-				else
-					fail "@instantiate_level not set to an acceptable value [:top, :sub_block]"
-				end
+        if @inst_level == :sub_block
+          bom_file.puts("#{indent}def instantiate_sub_blocks(options = {})")
+        elsif @inst_level == :top
+          bom_file.puts("#{indent}def initialize(options = {})")
+        else
+          fail '@instantiate_level not set to an acceptable value [:top, :sub_block]'
+        end
         indent += '  '
         # This method is recursive (indirectly) so file_content should find all BoM and include file strings
         create_file_content(@obj, indent)

--- a/lib/cross_origen/origen_format.rb
+++ b/lib/cross_origen/origen_format.rb
@@ -21,15 +21,18 @@ module CrossOrigen
       incl:  "\# This file is created by Origen via CrossOrigen::OrigenFormat#export, and is read-only"
     }
 
-    attr_reader :obj, :top_level_class, :top_level_hierarchy, :output_dir, :top_level_path, :incl_path, :incl_dir, :file_content
+    attr_reader :obj, :top_level_class, :top_level_hierarchy, :output_dir, :top_level_path, :incl_path, :incl_dir, :file_content, :inst_level
 
     def initialize(options = {})
       options = {
         obj:  $dut,
-        path: "#{Origen.root!}/output"
+        path: "#{Origen.root!}/output",
+				instantiate_level: :top
       }.update(options)
       @obj = options[:obj]
       @output_dir = options[:path]
+			@inst_level = options[:instantiate_level]
+			fail "@instantiate_level must be either set to ':top' or ':sub_block'" unless [:top, :sub_block].include?(@inst_level)
       @top_level_path = "#{output_dir}/top_level.rb"
       @incl_path = "#{output_dir}/sub_blocks.rb"
       @incl_dir = "#{output_dir}/import"
@@ -72,12 +75,22 @@ module CrossOrigen
         bom_file.puts(FILE_COMMENTS[:incl])
         bom_file.puts("require_relative 'sub_blocks'")
         @top_level_hierarchy.each do |name, obj|
-          bom_file.puts("#{indent}#{obj} #{name.split('::').last}")
-          indent += '  '
+					if(@inst_level == :sub_block && @top_level_hierarchy.keys.last == name)
+						obj = "module"
+						name = "SubBlocks"
+				  end
+					bom_file.puts("#{indent}#{obj} #{name.split('::').last}")
+					indent += '  '
         end
         bom_file.puts("#{indent}include Origen::Model")
         bom_file.puts('')
-        bom_file.puts("#{indent}def initialize(options = {})")
+				if @inst_level == :sub_block
+					bom_file.puts("#{indent}def instantiate_sub_blocks(options = {})")
+				elsif @inst_level == :top
+					bom_file.puts("#{indent}def initialize(options = {})")
+				else
+					fail "@instantiate_level not set to an acceptable value [:top, :sub_block]"
+				end
         indent += '  '
         # This method is recursive (indirectly) so file_content should find all BoM and include file strings
         create_file_content(@obj, indent)

--- a/templates/web/examples/origen_export.md.erb
+++ b/templates/web/examples/origen_export.md.erb
@@ -15,7 +15,12 @@ Ruby files to be written.
 
 ### Implementation
 
-Here is an example of how to create the static Ruby files.
+There are two methods for instantiating device models:
+
+1. As a named Origen TopLevel class with a method #instantiate_sub_blocks to model the device
+2. As a generic SubBlocks module to model the device
+
+Option #1 is the default behavior and is handled in this manner:
 
 ~~~ruby
 $dut.to_origen(path: "#{Origen.root}/output/exported")
@@ -91,6 +96,56 @@ module CrossOrigen
     end
   end
 end
+~~~
+
+Why option #2?  Some Origen applications may serve multiple products and want the ability to swap the current
+TopLevel model using target instantitation.  
+
+~~~ruby
+origen i -t my_product
+~~~
+
+Here is a generic example of how an application may use option #2 in
+combination with the CrossOrigen import feature.  By passing the 'instantiate_level: :sub_block' to the #to_origen
+method, the device model is changed to a SubBlocks module implementation.  Notice that the #to_origen method is called
+inside the #on_load_target callback.  This is necessary as the #to_origen method accesses Origen.app.output_directory,
+which is not available until the target is instantiated.
+
+~~~ruby
+
+module MyOrigenApp
+  class Product
+    include Origen::TopLevel
+    include CrossOrigen
+    
+    attr_accessor :curr_prod, :curr_prod_xml, :top_origen_path
+	
+    def initialize(options = {})
+      options = {
+        curr_product: nil
+      }.update(options)
+      @curr_prod = options [:curr_product]
+      @curr_prod_xml = Pathname.new("#{Origen.root}/vendor/mycompany/products/#{curr_prod}/product_ipxact.xml")
+      @top_origen_path = Pathname.new("#{Origen.root}/vendor/mycompany/products/#{curr_prod}/top_level.rb")
+      # Import or instantiate registers
+      if @top_origen_path.exist?
+        Origen.log.info("Instantiating registers from Origen source for product #{curr_prod}...")
+        require @top_origen_path.to_s.chomp(".rb")
+        extend SubBlocks
+        instantiate_sub_blocks()
+      else
+        Origen.log.info("Importing IP-XACT registers for #{curr_prod}...")
+        cr_import(path: @curr_prod_xml)
+      end
+    end
+    
+    def on_load_target
+      to_origen(path: @top_origen_path, instantiate_level: :sub_block)
+    end
+    
+  end
+end  
+
 ~~~
 
 % end


### PR DESCRIPTION
This change allows an application to load any product as TopLevel by creating the model as a SubBlocks module versus a named class (current behavior).