### PR TITLE
Fixed issue #8 - IP-XACT import would erroneously set a register's re…

### DIFF
--- a/imports/ipxact.xml
+++ b/imports/ipxact.xml
@@ -319,6 +319,26 @@ xsi:schemaLocation="$REGMEM_HOME/builder/ipxact/schema/ipxact
 						<spirit:bitWidth>4</spirit:bitWidth>
 					</spirit:field>
 				</spirit:register>
+				<spirit:register>
+					<spirit:name>reg1</spirit:name>
+					<spirit:description>register without reset mask to test CrossOrigen import process.
+					</spirit:description>
+					<spirit:addressOffset>0x4</spirit:addressOffset>
+					<spirit:size>8</spirit:size>
+					<spirit:reset>
+						<spirit:value>0x5a</spirit:value>
+					</spirit:reset>
+					<spirit:field>
+						<spirit:name>f0</spirit:name>
+						<spirit:bitOffset>0</spirit:bitOffset>
+						<spirit:bitWidth>4</spirit:bitWidth>
+					</spirit:field>
+					<spirit:field>
+						<spirit:name>f1</spirit:name>
+						<spirit:bitOffset>4</spirit:bitOffset>
+						<spirit:bitWidth>4</spirit:bitWidth>
+					</spirit:field>
+				</spirit:register>
 			</spirit:addressBlock>
 		</spirit:memoryMap>
 	</spirit:memoryMaps>

--- a/spec/ip_xact_spec.rb
+++ b/spec/ip_xact_spec.rb
@@ -22,7 +22,7 @@ describe 'IP-XACT' do
 
     it 'imports all registers' do
       $dut.am0.rf1.regs.size.should == 7
-      $dut.am0.rf2.regs.size.should == 1
+      $dut.am0.rf2.regs.size.should == 2
     end
 
     it 'pulls the register address' do
@@ -55,6 +55,10 @@ describe 'IP-XACT' do
 
     it 'extracts register path correctly' do
       $dut.am0.rf1.reg4.dirs.path.should == 'am0.rf1.reg4[3:2]'
+    end
+    
+    it 'extracts register reset value correctly when no reset mask is defined' do
+      $dut.am0.rf2.reg1.reset_value.should == 0x5a
     end
 
     it 'extracts an IP-level file correctly' do


### PR DESCRIPTION
…set_value to 0x0 if no reset_mask was declared.  Updated ipxact.rb to treat the reset mask as optional, issue a warning if a reset value was not declared, and updated spec testing to cover missing reset_mask case.