### PR TITLE
Updates for top-level register export to IP-XACT + coverage improvement

### DIFF
--- a/approved/default.ralf
+++ b/approved/default.ralf
@@ -33,6 +33,11 @@ system  {
         bytes 8;
         register mclkdiv (mclkdiv) @'h0 {
             bytes 2;
+            field div ([3:0]) {
+                access rw;
+                bits 4;
+                reset 'b0;
+            }
             field osch ([15]) {
                 access rw;
                 bits 1;

--- a/approved/ip_xact.xml
+++ b/approved/ip_xact.xml
@@ -91,6 +91,16 @@
             <spirit:mask>0xFFFF</spirit:mask>
           </spirit:reset>
           <spirit:field>
+            <spirit:name>div</spirit:name>
+            <spirit:description>Divider Value</spirit:description>
+            <spirit:bitOffset>0</spirit:bitOffset>
+            <spirit:bitWidth>4</spirit:bitWidth>
+            <spirit:access>rw</spirit:access>
+            <spirit:vendorExtensions>
+              <vendorExtensions:hdl_path>atx.div</vendorExtensions:hdl_path>
+            </spirit:vendorExtensions>
+          </spirit:field>
+          <spirit:field>
             <spirit:name>osch</spirit:name>
             <spirit:description>Oscillator (Hi)</spirit:description>
             <spirit:bitOffset>15</spirit:bitOffset>

--- a/approved/ip_xact_1685-2009.xml
+++ b/approved/ip_xact_1685-2009.xml
@@ -112,6 +112,19 @@
             <spirit:mask>0xFFFF</spirit:mask>
           </spirit:reset>
           <spirit:field>
+            <spirit:name>div</spirit:name>
+            <spirit:description>Divider Value</spirit:description>
+            <spirit:bitOffset>0</spirit:bitOffset>
+            <spirit:bitWidth>4</spirit:bitWidth>
+            <spirit:access>read-write</spirit:access>
+            <spirit:parameters>
+              <spirit:parameter>
+                <spirit:name>_hdlPath_</spirit:name>
+                <spirit:value>atx.div</spirit:value>
+              </spirit:parameter>
+            </spirit:parameters>
+          </spirit:field>
+          <spirit:field>
             <spirit:name>osch</spirit:name>
             <spirit:description>Oscillator (Hi)</spirit:description>
             <spirit:bitOffset>15</spirit:bitOffset>

--- a/approved/ip_xact_sub_block.xml
+++ b/approved/ip_xact_sub_block.xml
@@ -23,6 +23,13 @@
             <spirit:mask>0xFFFF</spirit:mask>
           </spirit:reset>
           <spirit:field>
+            <spirit:name>div</spirit:name>
+            <spirit:description>Divider Value</spirit:description>
+            <spirit:bitOffset>0</spirit:bitOffset>
+            <spirit:bitWidth>4</spirit:bitWidth>
+            <spirit:access>rw</spirit:access>
+          </spirit:field>
+          <spirit:field>
             <spirit:name>osch</spirit:name>
             <spirit:description>Oscillator (Hi)</spirit:description>
             <spirit:bitOffset>15</spirit:bitOffset>

--- a/approved/ip_xact_sub_block_1685.xml
+++ b/approved/ip_xact_sub_block_1685.xml
@@ -23,6 +23,19 @@
             <spirit:mask>0xFFFF</spirit:mask>
           </spirit:reset>
           <spirit:field>
+            <spirit:name>div</spirit:name>
+            <spirit:description>Divider Value</spirit:description>
+            <spirit:bitOffset>0</spirit:bitOffset>
+            <spirit:bitWidth>4</spirit:bitWidth>
+            <spirit:access>read-write</spirit:access>
+            <spirit:parameters>
+              <spirit:parameter>
+                <spirit:name>_hdlPath_</spirit:name>
+                <spirit:value>atx.div</spirit:value>
+              </spirit:parameter>
+            </spirit:parameters>
+          </spirit:field>
+          <spirit:field>
             <spirit:name>osch</spirit:name>
             <spirit:description>Oscillator (Hi)</spirit:description>
             <spirit:bitOffset>15</spirit:bitOffset>

--- a/lib/cross_origen_dev/dut.rb
+++ b/lib/cross_origen_dev/dut.rb
@@ -70,6 +70,10 @@ module CrossOrigenDev
           # 0 | Clock is the externally supplied bus clock bus_clk
           # 1 | Clock is the internal oscillator from the hardblock
           bit 15, :osch, reset: 1, access: :rw
+          # **Divider Value**
+          #
+          # Used to set clock divider value and test multi-bit import in CrossOrigen
+          bits 3..0, :div
         end
 
         # **Access Type Test Register**


### PR DESCRIPTION
Updated to_ipxact to allow for proper export of top-level registers (ex: models with no sub-blocks).  Added :addr_block_name to options hash to allow setting an addressBlock name in the XML output for this scenario.  Also added a multi-bit :div to MCLKDIV register in dut.rb to improve testing coverage.

The :addr_block_name addition was necessary to preserve existing behavior; if domain_name was used, it could potentially break existing model export & import, which was immediately visible in spec testing.