### PR TITLE
Updated IP-XACT export examples and usage explanations.

### DIFF
--- a/templates/web/examples.md.erb
+++ b/templates/web/examples.md.erb
@@ -6,7 +6,8 @@ The following examples are available which are used for testing but
 also provide some code examples of how to use the plugin for the various
 supported formats:
 
-* [IP-XACT Export](<%= path "examples/ip_xact_export" %>)
+* [Spirit 1.4 IP-XACT Export](<%= path "examples/ip_xact_export" %>)
+* [IEEE 1685-2009 IP-XACT Export](<%= path "examples/ip_xact_export_1685_2009" %>)
 * [RALF Export](<%= path "examples/ralf_export" %>)
 * [Origen Export](<%= path "examples/origen_export" %>)
 

--- a/templates/web/examples/ip_xact_export.md.erb
+++ b/templates/web/examples/ip_xact_export.md.erb
@@ -1,6 +1,6 @@
 % render "layouts/basic.html", tab: :examples do
 
-## IP-XACT Export
+## IP-XACT Export (Spirit 1.4)
 
 This page shows IP-XACT formatted XML that has been generated from an Origen
 representation of a module.

--- a/templates/web/examples/ip_xact_export_1685_2009.md.erb
+++ b/templates/web/examples/ip_xact_export_1685_2009.md.erb
@@ -1,0 +1,32 @@
+% render "layouts/basic.html", tab: :examples do
+
+## IP-XACT Export (IEEE 1685-2009)
+
+This page shows IEEE 1685-2009 IP-XACT formatted XML that has been generated from an Origen
+representation of a module.
+
+The exporter has the following options:
+
+* **:format** - nil by default, can be set to :uvm to include the associated vendor
+  extentions
+* **:include_bit_field_values** - true by default, when false the bit field values 
+  fields will not be output
+* **:schema** - nil by default, which assumes a Spirit 1.4 format. '1685-2009' is also supported.
+* **:mmap_name** - nil by default, can be set to any string name for the memory map name.
+* **:mmap_ref** - nil by default, can be set to any string name for the memory map reference used by a downstream tool.
+* **:vendor** - nil by default, can be set to any string name for the company name.
+* **:library** - nil by default, can be set to any string name for the library used by a downstream tool (ex: Magillem XML -> UVM conversion)
+%#* **:name** - nil by default, can be set to any string name for the an overall device/model name.
+%#* **:bus_interface** - nil by default, can be set to 'AMBA3' for an AMBA3 bus interface.
+
+For this example, targeting CrossOrigen's target/debug.rb, the code to generate this page is:
+
+~~~eruby
+<%= "<" + "%= $dut.to_ip_xact :format => :uvm, :schema=> '1685-2009', :mmap_name => 'RegisterMap', :vendor => 'origen-sdk.org', :library => 'id', :mmap_ref => 'test' %" + ">" %>
+~~~
+
+~~~xml
+<%= $dut.to_ip_xact :format => :uvm, :schema=> '1685-2009', :mmap_name => 'RegisterMap', :vendor => 'origen-sdk.org', :library => 'id', :mmap_ref => 'test' %>
+~~~
+
+% end

--- a/templates/web/index.md.erb
+++ b/templates/web/index.md.erb
@@ -35,7 +35,7 @@ Currently the following formats are supported:
 * CMSIS-SVD - Import registers and hierarchy
 * RALF (Synopsys format) - Export registers
 
-See the [examples](<%= path "examples" %>) for format specific documentation, but
+See the [Examples](<%= path "examples" %>) for format specific documentation, but
 most formats should follow this basic structure...
 
 #### Data Import  
@@ -100,7 +100,9 @@ and then compiled through Origen:
 <%= "<" + "%= $dut.to_ip_xact %" + ">" %>
 ~~~
 
-In future support may be added to export directly to a 3rd party tool if
+Please explore the [Examples](<%= path "examples" %>) page to see the differences between Spirit 1.4 and IEEE 1685-2009 IP-XACT export settings.
+
+In the future, support may be added to export directly to a 3rd party tool if
 it provides such an API.
 
 ### How To Setup a Development Environment


### PR DESCRIPTION
Added an IEEE 1685-2009 example page and highlighted the different options necessary for using that export method option.  No functionality change, only documentation.