### PR TITLE
Allows newer versions of sanitize for compatibility with other gems

### DIFF
--- a/cross_origen.gemspec
+++ b/cross_origen.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
 
   # Add any gems that your plugin needs to run within a host application
   spec.add_runtime_dependency "origen", ">= 0.59.7"
-  spec.add_runtime_dependency "sanitize", "~>4.0"
+  spec.add_runtime_dependency "sanitize", ">= 4.0"
 end


### PR DESCRIPTION
Ran 'origen specs' and seemed fine, not sure why sanitized was locked..